### PR TITLE
v0.2.0: standalone logger, shared engine, heartbeat, ClearML

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, "feature/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with test dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install .[trainer]
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Install package with test dependencies
         run: |
           python -m pip install --upgrade pip setuptools
+          pip install pytest
           pip install .[trainer]
+        timeout-minutes: 10
 
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.egg-info/
+build/
+dist/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,153 +1,138 @@
 # Messenger Logger Callback
 
-A custom Hugging Face Trainer Callback for sending training logs and custom data to a remote server with authentication.
-
-## Overview
-
-`messenger-logger-callback` is a Python library designed to easily integrate remote logging into your Hugging Face Trainer workflows. It provides a `TrainerCallback` that automatically captures standard training metrics (loss, learning rate, epoch, etc.) and sends them as JSON payloads to a specified HTTP endpoint. Additionally, it offers a flexible method to send arbitrary custom data from anywhere in your application.
-
-This library is particularly useful for:
-
-* Centralized logging of machine learning experiments.
-* Real-time monitoring of training progress on a remote dashboard.
-* Integrating with custom notification systems (e.g., Telegram bots, Slack webhooks) by having a server endpoint process the received logs.
-
-## Features
-
-* **Hugging Face Trainer Integration**: Seamlessly plugs into the Hugging Face `Trainer` class.
-* **Automatic Log Capture**: Intercepts `on_log`, `on_train_begin`, `on_train_end`, and `on_epoch_end` events.
-* **Custom Log Sending**: Provides a `send_custom_log` method for sending any arbitrary JSON data.
-* **Flexible Configuration**: Server URL and authentication token can be provided via constructor arguments or environment variables.
-* **Robust Error Handling**: Includes try-except blocks for network requests to gracefully handle timeouts, connection errors, and HTTP errors, printing informative messages without crashing your training.
-* **Authentication Support**: Supports sending a Bearer token in the `Authorization` header for secure communication with your logging server.
+A Python library for sending training logs to a remote server. Works as a **standalone logger** for any training loop or as a **Hugging Face Trainer Callback**.
 
 ## Installation
 
-You can install `messenger-logger-callback` using pip:
-
 ```bash
+# Standalone (no transformers dependency)
 pip install messenger-logger-callback
+
+# With Hugging Face Trainer support
+pip install messenger-logger-callback[trainer]
 ```
 
-## Usage
+## Quick Start: Standalone Logger
 
-### 1. Basic Integration with Hugging Face Trainer
+Use `MessengerLogger` in any training loop — plain PyTorch, Lightning, or anything else.
 
-```Python
-from transformers import Trainer, TrainingArguments
-from messenger_logger.callback import MessengerLoggerCallback
-import os
+```python
+from messenger_logger import MessengerLogger
 
-# --- Configure your server URL and optional authentication token, username, and metadata ---
-# Option A: Pass directly to the constructor
-messenger_logger = MessengerLoggerCallback(
-    server_url="http://your-logging-server.com/api/logs",
-    project_name="my_awesome_model",
-    run_id="experiment_v2",
-    auth_token="your_secret_api_token",
-    author_username="john.doe",
-    metadata={"framework": "pytorch", "model_type": "bert-large"}
+logger = MessengerLogger(
+    server_url="http://your-server:5000/api/logs",
+    project_name="resnet_experiment",
+    run_id="run_v3",
+    author_username="riko",
 )
 
-# Option B: Set as environment variables (recommended for production)
-# os.environ["MESSENGER_LOGGER_SERVER_URL"] = "http://your-logging-server.com/api/logs"
-# os.environ["MESSENGER_LOGGER_AUTH_TOKEN"] = "your_secret_api_token"
-# os.environ["MESSENGER_LOGGER_AUTHOR_USERNAME"] = "jane.smith"
-# os.environ["MESSENGER_LOGGER_METADATA"] = '{"dataset": "squad", "batch_size": 32}'
+logger.start()
 
-# If using environment variables, you can omit the arguments:
-# messenger_logger = MessengerLoggerCallback(
-#     project_name="my_awesome_model",
-#     run_id="experiment_v2"
-# )
+for epoch in range(num_epochs):
+    for step, batch in enumerate(dataloader):
+        loss = train_step(batch)
+        global_step += 1
+        logger.log(step=global_step, epoch=epoch, metrics={"loss": loss.item()})
+    logger.epoch_end(epoch)
 
-...
+logger.finish()
+```
+
+### Available Methods
+
+| Method | Description |
+|--------|-------------|
+| `start()` | Signal training start. Begins heartbeat. |
+| `log(step, metrics, epoch=None)` | Log training metrics at a given step. |
+| `epoch_end(epoch)` | Signal end of an epoch. |
+| `log_custom(data)` | Send arbitrary custom data. |
+| `finish()` | Signal training end. Stops heartbeat. |
+
+## Quick Start: Hugging Face Trainer
+
+Use `MessengerLoggerCallback` as a drop-in Trainer callback.
+
+```python
+from transformers import Trainer, TrainingArguments
+from messenger_logger.callback import MessengerLoggerCallback
+
+logger = MessengerLoggerCallback(
+    server_url="http://your-server:5000/api/logs",
+    project_name="bert_finetune",
+    run_id="experiment_v2",
+    auth_token="your_secret_token",
+    author_username="riko",
+    metadata={"model": "bert-large", "dataset": "squad"},
+)
 
 trainer = Trainer(
     model=model,
     args=training_args,
-    train_dataset=dataset["train"],
-    callbacks=[messenger_logger] # Add your custom callback here
+    train_dataset=train_dataset,
+    callbacks=[logger],
 )
+trainer.train()
 ```
 
-### 2. Sending Custom Logs
-You can send arbitrary data at any point using the send_custom_log method:
+The callback automatically captures `on_log`, `on_train_begin`, `on_train_end`, and `on_epoch_end` events.
 
-```Python
-from messenger_logger.callback import MessengerLoggerCallback
-import os
+You can also send custom data at any point:
 
-# Ensure the logger is initialized (e.g., from environment variables)
-# os.environ["MESSENGER_LOGGER_SERVER_URL"] = "http://localhost:5000/api/logs"
-# os.environ["MESSENGER_LOGGER_AUTH_TOKEN"] = "my_custom_token"
-# os.environ["MESSENGER_LOGGER_AUTHOR_USERNAME"] = "jane.smith"
-custom_logger = MessengerLoggerCallback(
-    server_url="http://localhost:5000/api/logs", # Or omit if using env vars
-    project_name="my_inference_project",
-    run_id="prediction_run_1"
-)
-
-# Send custom data, e.g., after model evaluation or deployment
-custom_logger.send_custom_log({
-    "event": "model_evaluation_complete",
-    "model_version": "v1.2.0",
-    "evaluation_metrics": {
-        "accuracy": 0.92,
-        "f1_score": 0.915,
-        "precision": 0.90,
-        "recall": 0.93
-    },
-    "dataset_info": "test_set_2023-01-15"
-})
-
-custom_logger.send_custom_log({
-    "event": "alert",
-    "level": "CRITICAL",
-    "message": "High GPU temperature detected on node gpu-01",
-    "temperature_celsius": 85,
-    "timestamp": "2023-10-27T10:30:00Z"
+```python
+logger.send_custom_log({
+    "event": "evaluation_complete",
+    "accuracy": 0.95,
+    "f1": 0.93,
 })
 ```
+
+## Heartbeat
+
+A background thread sends a lightweight heartbeat signal to the server every 60 seconds by default. This allows the server to detect crashed or stalled runs much faster than waiting for missing log events.
+
+- **On by default** with a 60-second interval.
+- Starts when training begins, stops when training ends.
+- If the training process crashes, the heartbeat stops automatically.
+
+To change the interval or disable:
+
+```python
+# Custom interval (30 seconds)
+logger = MessengerLogger(server_url="...", heartbeat_interval=30)
+
+# Disable heartbeat
+logger = MessengerLogger(server_url="...", heartbeat_interval=None)
+```
+
+## ClearML Integration
+
+If [ClearML](https://clear.ml/) is active in your training script, the library automatically detects the current task and includes a link to the ClearML dashboard in every payload sent to the server. No configuration needed — if `clearml` is installed and a task is running, the link is captured.
 
 ## Configuration
 
-### MessengerLoggerCallback can be configured using a three-tiered precedence system:
-
-Constructor Arguments: Take the highest precedence.
-
-Environment Variables: Overridden by constructor arguments.
-
-.env File: Loaded if dotenv_path is provided, and overridden by both environment variables and constructor arguments.
-
-### The available arguments and corresponding environment variables are:
+Settings can be provided via constructor arguments, environment variables, or a `.env` file. Constructor arguments take highest precedence, then environment variables, then `.env` file values.
 
 | Constructor Argument | Environment Variable | Description |
-| -----| ----- | ----- |
-| server_url | MESSENGER_LOGGER_SERVER_URL | The HTTP endpoint to send logs to. Required. |
-| project_name | (n/a) | A string identifier for your project. Defaults to "default_project". |
-| run_id | (n/a) | A unique identifier for the current training run. If not provided, a timestamp-based ID is generated. |
-| auth_token | MESSENGER_LOGGER_AUTH_TOKEN | An authentication token for the Authorization header. |
-| author_username | MESSENGER_LOGGER_AUTHOR_USERNAME | The username of the author. Defaults to "anonymous". |
-| metadata | MESSENGER_LOGGER_METADATA | A dictionary of static metadata. The environment variable should be a valid JSON string
-| dotenv_path | MESSENGER_LOGGER_DOTENV | Path to a .env file to load variables from. |
-
+|---------------------|---------------------|-------------|
+| `server_url` | `MESSENGER_LOGGER_SERVER_URL` | HTTP endpoint to send logs to. **Required.** |
+| `project_name` | — | Project identifier. Default: `"default_project"`. |
+| `run_id` | — | Unique run identifier. Auto-generated if omitted. |
+| `auth_token` | `MESSENGER_LOGGER_AUTH_TOKEN` | Bearer token for the Authorization header. |
+| `author_username` | `MESSENGER_LOGGER_AUTHOR_USERNAME` | Who started the run. Default: `"anonymous"`. |
+| `metadata` | `MESSENGER_LOGGER_METADATA` | Static metadata dict. Env var should be a JSON string. |
+| `dotenv_path` | `MESSENGER_LOGGER_DOTENV` | Path to a `.env` file to load config from. |
+| `heartbeat_interval` | — | Seconds between heartbeats. Default: `60`. Set to `None` to disable. |
 
 ## Error Handling
-The library includes robust error handling for network requests. If the logging server is unavailable, times out, or returns an HTTP error (4xx/5xx), a warning or error message will be printed to the console, but your training script will continue to run without interruption.
 
-Example error messages you might see:
+Network errors (timeouts, connection failures, HTTP errors) are caught and printed as warnings. They never crash your training. Example messages:
 
-``
-Warning: Request to http://localhost:5000/api/logs timed out for step 10. The server did not respond within the expected time.
-
-Error: Could not connect to server at http://localhost:9999/api/logs for step N/A. The server might be unavailable or the URL is incorrect. Error details: ...
-
-Error: HTTP error occurred while sending logs for step 20. Status: 401, Response: Unauthorized. Check server logs for more details.
-``
-
-## Contributing
-Contributions are welcome! Please feel free to open issues or submit pull requests on the GitHub repository.
+```
+Warning: Request to http://... timed out for step 10.
+Error: Could not connect to server at http://... for step 20.
+Error: HTTP error occurred while sending logs for step 30. Status: 401.
+```
 
 ## License
-This project is licensed under the MIT License - see the LICENSE file for details.
+
+MIT

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Python library for sending training logs to a remote server. Works as a **standalone logger** for any training loop or as a **Hugging Face Trainer Callback**.
 
+Pairs with [telegram-log-service](https://github.com/Riko0/telegram_log_service) for real-time Telegram alerts.
+
 ## Installation
 
 ```bash

--- a/messenger_logger/__init__.py
+++ b/messenger_logger/__init__.py
@@ -1,0 +1,6 @@
+from .logger import MessengerLogger
+
+try:
+    from .callback import MessengerLoggerCallback
+except ImportError:
+    pass

--- a/messenger_logger/callback.py
+++ b/messenger_logger/callback.py
@@ -1,342 +1,154 @@
-import requests
-import json
-import os
-import datetime
 import dataclasses
-import dotenv
-from transformers import TrainerCallback, TrainingArguments, TrainerState, TrainerControl
 from typing import Dict, Any, Optional
+
+from transformers import TrainerCallback, TrainingArguments, TrainerState, TrainerControl
+
+from .engine import LoggerEngine
+
 
 class MessengerLoggerCallback(TrainerCallback):
     """
-    A custom Hugging Face Trainer Callback to send training logs and custom data to a remote server.
+    Hugging Face Trainer Callback that sends training events to a remote server.
 
-    This callback intercepts logging events from the Trainer and sends the
-    relevant metrics (loss, learning rate, epoch, etc.) as a JSON payload
-    to a specified HTTP endpoint. It also provides a method to send custom,
-    arbitrary data.
-
-    Configuration can be provided through direct arguments, environment variables,
-    or a .env file.
+    Intercepts Trainer lifecycle events (log, train begin/end, epoch end) and
+    forwards them via HTTP. Also provides send_custom_log for arbitrary data.
 
     Args:
-        server_url (str, optional): The URL of the server endpoint where logs should be sent.
-                                    If not provided, it will attempt to read from
-                                    the MESSENGER_LOGGER_SERVER_URL environment variable.
-                                    Example: "http://your-server.com/api/logs"
-        project_name (str, optional): An identifier for the training project.
-                                      Defaults to "default_project".
-        run_id (str, optional): A unique identifier for the current training run.
-                                If not provided, a unique ID will be generated
-                                based on the current timestamp.
-        auth_token (str, optional): An authentication token to include in the request headers.
-                                    If not provided, it will attempt to read from
-                                    the MESSENGER_LOGGER_AUTH_TOKEN environment variable.
-        author_username (str, optional): The username of the author who initiated the run.
-                                         Defaults to "anonymous" if not provided. This
-                                         can be read from the MESSENGER_LOGGER_AUTHOR_USERNAME
-                                         environment variable.
-        metadata (Dict[str, Any], optional): A dictionary of static metadata to include with every log.
-                                             This can be passed directly or as a JSON string
-                                             in the MESSENGER_LOGGER_METADATA environment variable.
-        dotenv_path (str, optional): Path to a .env file to load environment variables from.
-                                     Defaults to None. This
-                                     can be read from the MESSENGER_LOGGER_DOTENV
-                                     environment variable.
+        server_url: The URL of the server endpoint. Falls back to
+            MESSENGER_LOGGER_SERVER_URL env var.
+        project_name: Identifier for the training project.
+        run_id: Unique identifier for this run. Auto-generated if omitted.
+        auth_token: Bearer token for the Authorization header. Falls back to
+            MESSENGER_LOGGER_AUTH_TOKEN env var.
+        author_username: Who started this run. Falls back to
+            MESSENGER_LOGGER_AUTHOR_USERNAME env var, then "anonymous".
+        metadata: Static key-value pairs included in every payload.
+        dotenv_path: Path to a .env file to load config from.
+        heartbeat_interval: Seconds between heartbeat pings (default 60).
+            Set to None or 0 to disable.
     """
-    def __init__(self, server_url: Optional[str] = None, project_name: str = "default_project",
-                 run_id: Optional[str] = None, auth_token: Optional[str] = None,
-                 author_username: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,
-                 dotenv_path: Optional[str] = None):
 
-        # Load environment variables from the specified .env file if a path is provided.
-        self.dotenv_path = dotenv_path if dotenv_path else os.getenv("MESSENGER_LOGGER_DOTENV")
-        if self.dotenv_path:
-            try:
-                dotenv.load_dotenv(dotenv_path=self.dotenv_path)
-                print(f"Loaded environment variables from {self.dotenv_path}")
-            except Exception as e:
-                print(f"Warning: Could not load .env file from {self.dotenv_path}. Error: {e}")
+    def __init__(
+        self,
+        server_url: Optional[str] = None,
+        project_name: str = "default_project",
+        run_id: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        author_username: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        dotenv_path: Optional[str] = None,
+        heartbeat_interval: Optional[int] = 60,
+    ):
+        self._engine = LoggerEngine(
+            server_url=server_url,
+            project_name=project_name,
+            run_id=run_id,
+            auth_token=auth_token,
+            author_username=author_username,
+            metadata=metadata,
+            dotenv_path=dotenv_path,
+            heartbeat_interval=heartbeat_interval,
+        )
 
-        # Determine server_url: Prioritize direct argument, then env variable.
-        self.server_url = server_url if server_url else os.getenv("MESSENGER_LOGGER_SERVER_URL")
-        if not self.server_url:
-            raise ValueError(
-                "server_url must be provided either as an argument, via an environment "
-                "variable, or within a loaded .env file."
-            )
+    @property
+    def project_name(self) -> str:
+        return self._engine.project_name
 
-        # Determine auth_token: Prioritize direct argument, then env variable.
-        self.auth_token = auth_token if auth_token else os.getenv("MESSENGER_LOGGER_AUTH_TOKEN")
-        if self.auth_token:
-            print("Authentication token will be used for server requests.")
-
-        # Determine author_username: Prioritize direct argument, then env variable, otherwise default.
-        self.author_username = author_username if author_username else os.getenv("MESSENGER_LOGGER_AUTHOR_USERNAME", "anonymous")
-
-        # Determine metadata: Prioritize direct argument, then parsed JSON from env variable.
-        self.metadata = metadata or {}
-        env_metadata_str = os.getenv("MESSENGER_LOGGER_METADATA")
-        if env_metadata_str:
-            try:
-                env_metadata = json.loads(env_metadata_str)
-                # Merge with any existing metadata from direct arguments
-                self.metadata.update(env_metadata)
-                print("Loaded metadata from environment variable.")
-            except json.JSONDecodeError as e:
-                print(f"Error: Could not parse MESSENGER_LOGGER_METADATA environment variable as JSON. Error: {e}")
-            except Exception as e:
-                print(f"An unexpected error occurred while processing metadata from env variable: {e}")
-
-
-        self.project_name = project_name
-        # Simple unique ID based on timestamp if not provided
-        self.run_id = run_id if run_id else f"run_{int(datetime.datetime.now().timestamp())}"
-        print(f"MessengerLoggerCallback initialized for project '{self.project_name}', run '{self.run_id}' by '{self.author_username}'")
-        print(f"Logs will be sent to: {self.server_url}")
-        if self.metadata:
-            print(f"Including static metadata: {self.metadata}")
+    @property
+    def run_id(self) -> str:
+        return self._engine.run_id
 
     def _get_trainer_state_info(self, state: TrainerState) -> Dict[str, Any]:
-        """
-        Extracts all attributes from TrainerState into a dictionary using dataclasses.asdict.
-        This handles serialization of basic types and nested dataclasses automatically.
-        """
+        """Extract trainer state as a plain dict, trimming log_history."""
         _state = dataclasses.asdict(state)
         log_history = _state.get("log_history", [])
         _state["log_history"] = log_history[:5]
         return _state
 
-    def _send_payload(self, payload: Dict[str, Any], step: Optional[int] = None):
-        """Helper method to send a JSON payload to the server with error handling."""
-        headers = {"Content-Type": "application/json"}
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
-
-        final_payload = {
-            "author_username": self.author_username,
-            **self.metadata,
-            **payload,
-        }
-
-        try:
-            response = requests.post(self.server_url, json=final_payload, headers=headers, timeout=10)
-            response.raise_for_status()
-        except requests.exceptions.Timeout:
-            print(f"Warning: Request to {self.server_url} timed out for step {step if step is not None else 'N/A'}. "
-                  "The server did not respond within the expected time.")
-        except requests.exceptions.ConnectionError as e:
-            print(f"Error: Could not connect to server at {self.server_url} for step {step if step is not None else 'N/A'}. "
-                  f"The server might be unavailable or the URL is incorrect. Error details: {e}")
-        except requests.exceptions.HTTPError as e:
-            print(f"Error: HTTP error occurred while sending logs for step {step if step is not None else 'N/A'}. "
-                  f"Status: {e.response.status_code}, Response: {e.response.text}. Check server logs for more details.")
-        except Exception as e:
-            print(f"An unexpected error occurred while sending logs for step {step if step is not None else 'N/A'}: {e}")
-
-    def on_log(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, logs: Dict[str, Any], **kwargs):
-        """
-        Event called after logging.
-
-        This method is triggered by the Trainer when new logs (metrics) are available.
-        It constructs a payload with the current training state and metrics,
-        and sends it to the configured server URL.
-        """
+    def on_train_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
         if state.is_world_process_zero:
-            payload = {
-                "project_name": self.project_name,
-                "run_id": self.run_id,
-                "event_type": "trainer_log",
-                "trainer_state": self._get_trainer_state_info(state),
-                "logs": logs,
-                "timestamp": datetime.datetime.now().isoformat()
-            }
-            self._send_payload(payload, state.global_step)
+            if not self._engine.clearml_link:
+                self._engine.clearml_link = self._engine._detect_clearml_link()
+                if self._engine.clearml_link:
+                    print(f"ClearML task detected: {self._engine.clearml_link}")
+            self._engine.send_event(
+                "training_started",
+                trainer_state=self._get_trainer_state_info(state),
+            )
+            self._engine.start_heartbeat()
+            print(
+                f"Training for project '{self.project_name}', "
+                f"run '{self.run_id}' has begun."
+            )
 
-    def on_train_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        """Event called at the beginning of training."""
+    def on_train_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
         if state.is_world_process_zero:
-            print(f"Training for project '{self.project_name}', run '{self.run_id}' has begun.")
-            self._send_status_update("training_started", state)
+            self._engine.stop_heartbeat()
+            self._engine.send_event(
+                "training_finished",
+                trainer_state=self._get_trainer_state_info(state),
+            )
+            print(
+                f"Training for project '{self.project_name}', "
+                f"run '{self.run_id}' has ended."
+            )
 
-    def on_train_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        """Event called at the end of training."""
+    def on_log(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        logs: Dict[str, Any],
+        **kwargs,
+    ):
         if state.is_world_process_zero:
-            print(f"Training for project '{self.project_name}', run '{self.run_id}' has ended.")
-            self._send_status_update("training_finished", state)
+            self._engine.send_event(
+                "trainer_log",
+                trainer_state=self._get_trainer_state_info(state),
+                logs=logs,
+            )
 
-    def on_epoch_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        """Event called at the end of an epoch."""
+    def on_epoch_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
         if state.is_world_process_zero:
-            print(f"Epoch {int(state.epoch)} ended for project '{self.project_name}', run '{self.run_id}'.")
-            self._send_status_update("epoch_ended", state)
-
-    def _send_status_update(self, event_type: str, state: TrainerState):
-        """Helper to send general status updates."""
-        payload = {
-            "project_name": self.project_name,
-            "run_id": self.run_id,
-            "event_type": event_type,
-            "trainer_state": self._get_trainer_state_info(state),
-            "timestamp": datetime.datetime.now().isoformat()
-        }
-        self._send_payload(payload, state.global_step)
+            self._engine.send_event(
+                "epoch_ended",
+                trainer_state=self._get_trainer_state_info(state),
+            )
+            print(
+                f"Epoch {int(state.epoch)} ended for project "
+                f"'{self.project_name}', run '{self.run_id}'."
+            )
 
     def send_custom_log(self, custom_data: Dict[str, Any]):
         """
-        Sends arbitrary custom data to the remote server.
+        Send arbitrary custom data to the remote server.
 
-        This method can be called directly by the user at any point in their
-        training script.
-
-        Note: In a distributed training environment (e.g., with multiple GPUs),
-        be mindful to call this method only from the main process to avoid
-        sending duplicate logs. You can check `trainer.state.is_world_process_zero`.
-
-        Args:
-            custom_data (Dict[str, Any]): A dictionary containing the custom data
-                                          to be sent.
+        In distributed training, call only from the main process
+        (check trainer.state.is_world_process_zero).
         """
         if not isinstance(custom_data, dict):
             print("Error: custom_data must be a dictionary.")
             return
-
-        payload = {
-            "project_name": self.project_name,
-            "run_id": self.run_id,
-            "event_type": "custom_log",
-            "custom_data": custom_data,
-            "timestamp": datetime.datetime.now().isoformat()
-        }
-        print(f"Sending custom log for project '{self.project_name}', run '{self.run_id}'.")
-        self._send_payload(payload)
-
-# Example Usage (how you would use this in your training script):
-if __name__ == "__main__":
-    # --- Demonstration of MessengerLoggerCallback ---
-    print("--- Demonstrating MessengerLoggerCallback instantiation ---")
-
-    # Scenario 1: Using direct arguments
-    print("\n--- Scenario 1: Using direct arguments ---")
-    try:
-        my_logger_direct = MessengerLoggerCallback(
-            server_url="http://localhost:5000/api/logs",
-            project_name="my_nlp_project_direct",
-            run_id="experiment_direct_v1",
-            auth_token="my_secret_direct_token",
-            author_username="john.doe",
-            metadata={"framework": "pytorch", "model_type": "bert-large", "hardware": "gpu"} # Direct metadata
+        self._engine.send_event("custom_log", custom_data=custom_data)
+        print(
+            f"Sending custom log for project '{self.project_name}', "
+            f"run '{self.run_id}'."
         )
-        print("Simulating log event for direct arguments...")
-        dummy_args = TrainingArguments(output_dir="./tmp_output_direct")
-        dummy_state = TrainerState()
-        dummy_state.global_step = 10
-        dummy_state.epoch = 0.1
-        dummy_state.is_training = True
-        dummy_state.is_world_process_zero = True # Simulate main process
-        dummy_control = TrainerControl()
-        dummy_logs = {"loss": 0.1234}
-        my_logger_direct.on_log(dummy_args, dummy_state, dummy_control, dummy_logs)
-        my_logger_direct.send_custom_log({"message": "Direct argument test complete"})
-    except ValueError as e:
-        print(f"Configuration Error (Direct Arguments): {e}")
-    except Exception as e:
-        print(f"An error occurred during direct argument demonstration: {e}")
-
-    # Scenario 2: Using environment variables
-    print("\n--- Scenario 2: Using environment variables ---")
-    os.environ["MESSENGER_LOGGER_SERVER_URL"] = "http://localhost:5000/api/logs"
-    os.environ["MESSENGER_LOGGER_AUTH_TOKEN"] = "my_secret_env_token"
-    os.environ["MESSENGER_LOGGER_AUTHOR_USERNAME"] = "jane.smith"
-    os.environ["MESSENGER_LOGGER_METADATA"] = '{"dataset": "squad", "batch_size": 32}' # JSON metadata
-
-    try:
-        my_logger_env = MessengerLoggerCallback(
-            project_name="my_nlp_project_env",
-            run_id="experiment_env_v1"
-        )
-        print("Simulating log event for environment variables...")
-        dummy_args_env = TrainingArguments(output_dir="./tmp_output_env")
-        dummy_state_env = TrainerState()
-        dummy_state_env.global_step = 20
-        dummy_state_env.epoch = 0.2
-        dummy_state_env.is_training = True
-        dummy_state_env.is_world_process_zero = True # Simulate main process
-        dummy_control_env = TrainerControl()
-        dummy_logs_env = {"loss": 0.5678, "learning_rate": 5e-5}
-        my_logger_env.on_log(dummy_args_env, dummy_state_env, dummy_control_env, dummy_logs_env)
-        my_logger_env.send_custom_log({"message": "Environment variable test complete"})
-    except ValueError as e:
-        print(f"Configuration Error (Environment Variables): {e}")
-    except Exception as e:
-        print(f"An error occurred during environment variable demonstration: {e}")
-    finally:
-        del os.environ["MESSENGER_LOGGER_SERVER_URL"]
-        if "MESSENGER_LOGGER_AUTH_TOKEN" in os.environ:
-            del os.environ["MESSENGER_LOGGER_AUTH_TOKEN"]
-        if "MESSENGER_LOGGER_AUTHOR_USERNAME" in os.environ:
-            del os.environ["MESSENGER_LOGGER_AUTHOR_USERNAME"]
-        if "MESSENGER_LOGGER_METADATA" in os.environ:
-            del os.environ["MESSENGER_LOGGER_METADATA"]
-
-    # Scenario 3: Using a .env file for configuration
-    print("\n--- Scenario 3: Using a .env file for configuration ---")
-    dotenv_file_path = "temp.env"
-    with open(dotenv_file_path, "w") as f:
-        f.write("MESSENGER_LOGGER_SERVER_URL=http://localhost:5000/api/logs\n")
-        f.write("MESSENGER_LOGGER_AUTH_TOKEN=my_secret_dotenv_token\n")
-        f.write("MESSENGER_LOGGER_AUTHOR_USERNAME=steve.rogers\n")
-        f.write("MESSENGER_LOGGER_METADATA='{\"learning_rate\": 5e-5, \"optimizer\": \"adamw\"}'\n")
-
-    try:
-        my_logger_dotenv = MessengerLoggerCallback(
-            project_name="my_nlp_project_dotenv",
-            run_id="experiment_dotenv_v1",
-            dotenv_path=dotenv_file_path
-        )
-        print("Simulating log event for .env file configuration...")
-        dummy_args_dotenv = TrainingArguments(output_dir="./tmp_output_dotenv")
-        dummy_state_dotenv = TrainerState()
-        dummy_state_dotenv.global_step = 40
-        dummy_state_dotenv.epoch = 0.4
-        dummy_state_dotenv.is_training = True
-        dummy_state_dotenv.is_world_process_zero = True # Simulate main process
-        dummy_control_dotenv = TrainerControl()
-        dummy_logs_dotenv = {"loss": 0.3333}
-        my_logger_dotenv.on_log(dummy_args_dotenv, dummy_state_dotenv, dummy_control_dotenv, dummy_logs_dotenv)
-        my_logger_dotenv.send_custom_log({"message": ".env file test complete"})
-    except ValueError as e:
-        print(f"Configuration Error (.env File): {e}")
-    except Exception as e:
-        print(f"An error occurred during .env file demonstration: {e}")
-    finally:
-        if os.path.exists(dotenv_file_path):
-            os.remove(dotenv_file_path)
-
-    # Scenario 4: Server not available
-    print("\n--- Scenario 4: Demonstrating server unavailability error handling ---")
-    os.environ["MESSENGER_LOGGER_SERVER_URL"] = "http://localhost:9999/api/logs"
-    try:
-        my_logger_unavailable = MessengerLoggerCallback(
-            project_name="my_nlp_project_unavailable",
-            run_id="experiment_unavailable_v1"
-        )
-        print("Attempting to send log to unavailable server...")
-        dummy_args_un = TrainingArguments(output_dir="./tmp_output_un")
-        dummy_state_un = TrainerState()
-        dummy_state_un.global_step = 50
-        dummy_state_un.epoch = 0.5
-        dummy_state_un.is_training = True
-        dummy_state_un.is_world_process_zero = True # Simulate main process
-        dummy_control_un = TrainerControl()
-        dummy_logs_un = {"loss": 0.999}
-        my_logger_unavailable.on_log(dummy_args_un, dummy_state_un, dummy_control_un, dummy_logs_un)
-    except ValueError as e:
-        print(f"Configuration Error (Unavailable Server): {e}")
-    except Exception as e:
-        print(f"An error occurred during unavailable server demonstration: {e}")
-    finally:
-        if "MESSENGER_LOGGER_SERVER_URL" in os.environ:
-            del os.environ["MESSENGER_LOGGER_SERVER_URL"]
-
-    print("\nDemonstration complete. Check the console output for messages.")

--- a/messenger_logger/engine.py
+++ b/messenger_logger/engine.py
@@ -1,0 +1,203 @@
+import requests
+import json
+import os
+import datetime
+import threading
+import dotenv
+from typing import Dict, Any, Optional
+
+
+class LoggerEngine:
+    """
+    Shared core for sending training events to a remote logging server.
+
+    Handles configuration resolution, HTTP transport, ClearML auto-detection,
+    heartbeat background thread, and payload construction. Used internally by
+    both MessengerLogger (standalone) and MessengerLoggerCallback (HF Trainer).
+    """
+
+    def __init__(
+        self,
+        server_url: Optional[str] = None,
+        project_name: str = "default_project",
+        run_id: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        author_username: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        dotenv_path: Optional[str] = None,
+        heartbeat_interval: Optional[int] = 60,
+    ):
+        self._load_dotenv(dotenv_path)
+        self.server_url = self._resolve_server_url(server_url)
+        self.auth_token = self._resolve_auth_token(auth_token)
+        self.author_username = self._resolve_author_username(author_username)
+        self.metadata = self._resolve_metadata(metadata)
+        self.project_name = project_name
+        self.run_id = run_id or f"run_{int(datetime.datetime.now().timestamp())}"
+        self.heartbeat_interval = heartbeat_interval
+
+        self.clearml_link = self._detect_clearml_link()
+
+        self._heartbeat_stop: Optional[threading.Event] = None
+        self._heartbeat_thread: Optional[threading.Thread] = None
+
+        print(
+            f"LoggerEngine initialized for project '{self.project_name}', "
+            f"run '{self.run_id}' by '{self.author_username}'"
+        )
+        print(f"Logs will be sent to: {self.server_url}")
+        if self.clearml_link:
+            print(f"ClearML task detected: {self.clearml_link}")
+        if self.metadata:
+            print(f"Including static metadata: {self.metadata}")
+
+    # --- Configuration resolution ---
+
+    def _load_dotenv(self, dotenv_path: Optional[str]):
+        self.dotenv_path = dotenv_path or os.getenv("MESSENGER_LOGGER_DOTENV")
+        if self.dotenv_path:
+            try:
+                dotenv.load_dotenv(dotenv_path=self.dotenv_path)
+                print(f"Loaded environment variables from {self.dotenv_path}")
+            except Exception as e:
+                print(f"Warning: Could not load .env file from {self.dotenv_path}. Error: {e}")
+
+    def _resolve_server_url(self, server_url: Optional[str]) -> str:
+        url = server_url or os.getenv("MESSENGER_LOGGER_SERVER_URL")
+        if not url:
+            raise ValueError(
+                "server_url must be provided either as an argument, via an environment "
+                "variable, or within a loaded .env file."
+            )
+        return url
+
+    def _resolve_auth_token(self, auth_token: Optional[str]) -> Optional[str]:
+        token = auth_token or os.getenv("MESSENGER_LOGGER_AUTH_TOKEN")
+        if token:
+            print("Authentication token will be used for server requests.")
+        return token
+
+    def _resolve_author_username(self, author_username: Optional[str]) -> str:
+        return author_username or os.getenv("MESSENGER_LOGGER_AUTHOR_USERNAME", "anonymous")
+
+    def _resolve_metadata(self, metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        result = metadata or {}
+        env_metadata_str = os.getenv("MESSENGER_LOGGER_METADATA")
+        if env_metadata_str:
+            try:
+                env_metadata = json.loads(env_metadata_str)
+                result.update(env_metadata)
+                print("Loaded metadata from environment variable.")
+            except json.JSONDecodeError as e:
+                print(f"Error: Could not parse MESSENGER_LOGGER_METADATA as JSON. Error: {e}")
+            except Exception as e:
+                print(f"Unexpected error processing metadata from env variable: {e}")
+        return result
+
+    # --- ClearML detection ---
+
+    def _detect_clearml_link(self) -> Optional[str]:
+        try:
+            from clearml import Task
+            task = Task.current_task()
+            if task:
+                return task.get_task_url()
+        except ImportError:
+            pass
+        except Exception:
+            pass
+        return None
+
+    # --- HTTP transport ---
+
+    def send_event(
+        self,
+        event_type: str,
+        trainer_state: Optional[Dict[str, Any]] = None,
+        logs: Optional[Dict[str, Any]] = None,
+        custom_data: Optional[Dict[str, Any]] = None,
+    ):
+        """Construct a full payload envelope and send it to the server."""
+        payload = {
+            "project_name": self.project_name,
+            "run_id": self.run_id,
+            "event_type": event_type,
+            "timestamp": datetime.datetime.now().isoformat(),
+        }
+        if trainer_state is not None:
+            payload["trainer_state"] = trainer_state
+        if logs is not None:
+            payload["logs"] = logs
+        if custom_data is not None:
+            payload["custom_data"] = custom_data
+        if self.clearml_link:
+            payload["clearml_link"] = self.clearml_link
+
+        step = (trainer_state or {}).get("global_step")
+        self._send_payload(payload, step)
+
+    def _send_payload(self, payload: Dict[str, Any], step: Optional[int] = None):
+        """Send a JSON payload to the server with error handling."""
+        headers = {"Content-Type": "application/json"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
+        final_payload = {
+            "author_username": self.author_username,
+            **self.metadata,
+            **payload,
+        }
+
+        try:
+            response = requests.post(
+                self.server_url, json=final_payload, headers=headers, timeout=10
+            )
+            response.raise_for_status()
+        except requests.exceptions.Timeout:
+            print(
+                f"Warning: Request to {self.server_url} timed out for step "
+                f"{step if step is not None else 'N/A'}. "
+                "The server did not respond within the expected time."
+            )
+        except requests.exceptions.ConnectionError as e:
+            print(
+                f"Error: Could not connect to server at {self.server_url} for step "
+                f"{step if step is not None else 'N/A'}. "
+                f"The server might be unavailable or the URL is incorrect. Error details: {e}"
+            )
+        except requests.exceptions.HTTPError as e:
+            print(
+                f"Error: HTTP error occurred while sending logs for step "
+                f"{step if step is not None else 'N/A'}. "
+                f"Status: {e.response.status_code}, Response: {e.response.text}. "
+                "Check server logs for more details."
+            )
+        except Exception as e:
+            print(
+                f"Unexpected error while sending logs for step "
+                f"{step if step is not None else 'N/A'}: {e}"
+            )
+
+    # --- Heartbeat ---
+
+    def start_heartbeat(self):
+        """Start a daemon thread that sends heartbeat events at a fixed interval."""
+        if not self.heartbeat_interval:
+            return
+        self._heartbeat_stop = threading.Event()
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat_loop, daemon=True
+        )
+        self._heartbeat_thread.start()
+        print(f"Heartbeat started (interval: {self.heartbeat_interval}s)")
+
+    def _heartbeat_loop(self):
+        while not self._heartbeat_stop.wait(self.heartbeat_interval):
+            self.send_event("heartbeat")
+
+    def stop_heartbeat(self):
+        """Stop the heartbeat background thread."""
+        if self._heartbeat_stop is not None:
+            self._heartbeat_stop.set()
+            self._heartbeat_thread = None
+            self._heartbeat_stop = None

--- a/messenger_logger/logger.py
+++ b/messenger_logger/logger.py
@@ -1,0 +1,109 @@
+from typing import Dict, Any, Optional
+
+from .engine import LoggerEngine
+
+
+class MessengerLogger:
+    """
+    Standalone training logger that sends events to a remote server.
+
+    Provides simple methods mirroring the training lifecycle (start, log,
+    epoch_end, finish) without requiring Hugging Face Transformers.
+
+    Args:
+        server_url: The URL of the server endpoint. Falls back to
+            MESSENGER_LOGGER_SERVER_URL env var.
+        project_name: Identifier for the training project.
+        run_id: Unique identifier for this run. Auto-generated if omitted.
+        auth_token: Bearer token for the Authorization header. Falls back to
+            MESSENGER_LOGGER_AUTH_TOKEN env var.
+        author_username: Who started this run. Falls back to
+            MESSENGER_LOGGER_AUTHOR_USERNAME env var, then "anonymous".
+        metadata: Static key-value pairs included in every payload.
+        dotenv_path: Path to a .env file to load config from.
+        heartbeat_interval: Seconds between heartbeat pings (default 60).
+            Set to None or 0 to disable.
+    """
+
+    def __init__(
+        self,
+        server_url: Optional[str] = None,
+        project_name: str = "default_project",
+        run_id: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        author_username: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        dotenv_path: Optional[str] = None,
+        heartbeat_interval: Optional[int] = 60,
+    ):
+        self._engine = LoggerEngine(
+            server_url=server_url,
+            project_name=project_name,
+            run_id=run_id,
+            auth_token=auth_token,
+            author_username=author_username,
+            metadata=metadata,
+            dotenv_path=dotenv_path,
+            heartbeat_interval=heartbeat_interval,
+        )
+        self._state: Dict[str, Any] = {
+            "global_step": 0,
+            "epoch": 0.0,
+            "is_training": False,
+        }
+
+    @property
+    def project_name(self) -> str:
+        return self._engine.project_name
+
+    @property
+    def run_id(self) -> str:
+        return self._engine.run_id
+
+    def start(self):
+        """Signal the beginning of training. Starts heartbeat if enabled."""
+        self._state["is_training"] = True
+        self._engine.send_event("training_started", trainer_state=dict(self._state))
+        self._engine.start_heartbeat()
+        print(f"Training started for project '{self.project_name}', run '{self.run_id}'.")
+
+    def log(self, step: int, metrics: Dict[str, Any], epoch: Optional[float] = None):
+        """
+        Log training metrics for a given step.
+
+        Args:
+            step: The current global step number.
+            metrics: Dictionary of metric names to values (e.g. {"loss": 0.5}).
+            epoch: Current epoch (optional, updates internal state if provided).
+        """
+        self._state["global_step"] = step
+        if epoch is not None:
+            self._state["epoch"] = epoch
+        self._engine.send_event(
+            "trainer_log", trainer_state=dict(self._state), logs=metrics
+        )
+
+    def epoch_end(self, epoch: int):
+        """Signal the end of an epoch."""
+        self._state["epoch"] = epoch
+        self._engine.send_event("epoch_ended", trainer_state=dict(self._state))
+        print(f"Epoch {epoch} ended for project '{self.project_name}', run '{self.run_id}'.")
+
+    def log_custom(self, data: Dict[str, Any]):
+        """
+        Send arbitrary custom data to the server.
+
+        Args:
+            data: Dictionary of custom data to send.
+        """
+        if not isinstance(data, dict):
+            print("Error: data must be a dictionary.")
+            return
+        self._engine.send_event("custom_log", custom_data=data)
+
+    def finish(self):
+        """Signal the end of training. Stops heartbeat."""
+        self._engine.stop_heartbeat()
+        self._state["is_training"] = False
+        self._engine.send_event("training_finished", trainer_state=dict(self._state))
+        print(f"Training finished for project '{self.project_name}', run '{self.run_id}'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "messenger-logger-callback"
-version = "0.1.4"
+version = "0.2.0"
 authors = [
   { name="Riko0", email="grigoriyalexeenko@gmail.com" },
 ]
-description = "A custom logger and Hugging Face Trainer Callback for sending logs to a remote server with authentication."
+description = "A training logger with Hugging Face Trainer integration and standalone API for sending logs to a remote server."
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
@@ -20,9 +20,11 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.25.1",
-    "transformers>=4.0.0",
-    "python-dotenv>=1.0.0"
+    "python-dotenv>=1.0.0",
 ]
+
+[project.optional-dependencies]
+trainer = ["transformers>=4.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/Riko0/messenger-logger-callback"

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,0 +1,83 @@
+"""Test the MessengerLoggerCallback against an unreachable server.
+
+All Trainer callback hooks must complete without raising.
+"""
+
+import unittest
+from unittest import mock
+
+from transformers import TrainingArguments, TrainerState, TrainerControl
+from messenger_logger.callback import MessengerLoggerCallback
+
+
+UNREACHABLE = "http://localhost:19999/api/logs"
+
+
+def _make_state(**overrides):
+    state = TrainerState()
+    state.global_step = overrides.get("global_step", 10)
+    state.epoch = overrides.get("epoch", 0.5)
+    state.is_training = overrides.get("is_training", True)
+    state.is_world_process_zero = overrides.get("is_world_process_zero", True)
+    return state
+
+
+class TestCallback(unittest.TestCase):
+    def setUp(self):
+        self.cb = MessengerLoggerCallback(
+            server_url=UNREACHABLE,
+            project_name="cb_project",
+            run_id="cb_run",
+            heartbeat_interval=None,
+        )
+        self.args = TrainingArguments(output_dir="/tmp/test_cb")
+        self.state = _make_state()
+        self.control = TrainerControl()
+
+    def test_properties(self):
+        self.assertEqual(self.cb.project_name, "cb_project")
+        self.assertEqual(self.cb.run_id, "cb_run")
+
+    def test_on_train_begin(self):
+        self.cb.on_train_begin(self.args, self.state, self.control)
+
+    def test_on_log(self):
+        self.cb.on_log(self.args, self.state, self.control, logs={"loss": 0.3})
+
+    def test_on_epoch_end(self):
+        self.cb.on_epoch_end(self.args, self.state, self.control)
+
+    def test_on_train_end(self):
+        self.cb.on_train_end(self.args, self.state, self.control)
+
+    def test_send_custom_log(self):
+        self.cb.send_custom_log({"key": "value"})
+
+    def test_send_custom_log_rejects_non_dict(self):
+        self.cb.send_custom_log("not a dict")
+
+    def test_skips_non_zero_process(self):
+        """Events from non-zero processes should be silently skipped."""
+        state = _make_state(is_world_process_zero=False)
+        with mock.patch.object(self.cb._engine, "send_event") as m:
+            self.cb.on_log(self.args, state, self.control, logs={"loss": 0.1})
+            m.assert_not_called()
+
+    def test_full_lifecycle(self):
+        self.cb.on_train_begin(self.args, self.state, self.control)
+        self.cb.on_log(self.args, self.state, self.control, logs={"loss": 0.5})
+        self.cb.on_epoch_end(self.args, self.state, self.control)
+        self.cb.send_custom_log({"info": "test"})
+        self.cb.on_train_end(self.args, self.state, self.control)
+
+    def test_on_log_payload(self):
+        with mock.patch.object(self.cb._engine, "_send_payload") as m:
+            self.cb.on_log(self.args, self.state, self.control, logs={"loss": 0.2})
+            payload = m.call_args[0][0]
+            self.assertEqual(payload["event_type"], "trainer_log")
+            self.assertEqual(payload["logs"], {"loss": 0.2})
+            self.assertIn("trainer_state", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,142 @@
+"""Test LoggerEngine configuration and payload construction."""
+
+import os
+import unittest
+from unittest import mock
+
+from messenger_logger.engine import LoggerEngine
+
+
+UNREACHABLE = "http://localhost:19999/api/logs"
+
+
+class TestEngineConfig(unittest.TestCase):
+    def test_server_url_from_arg(self):
+        engine = LoggerEngine(server_url=UNREACHABLE, heartbeat_interval=None)
+        self.assertEqual(engine.server_url, UNREACHABLE)
+
+    def test_server_url_from_env(self):
+        with mock.patch.dict(os.environ, {"MESSENGER_LOGGER_SERVER_URL": UNREACHABLE}):
+            engine = LoggerEngine(heartbeat_interval=None)
+            self.assertEqual(engine.server_url, UNREACHABLE)
+
+    def test_missing_server_url_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                LoggerEngine(heartbeat_interval=None)
+
+    def test_auth_token_from_arg(self):
+        engine = LoggerEngine(
+            server_url=UNREACHABLE, auth_token="tok123", heartbeat_interval=None,
+        )
+        self.assertEqual(engine.auth_token, "tok123")
+
+    def test_auth_token_from_env(self):
+        with mock.patch.dict(os.environ, {"MESSENGER_LOGGER_AUTH_TOKEN": "envtok"}):
+            engine = LoggerEngine(server_url=UNREACHABLE, heartbeat_interval=None)
+            self.assertEqual(engine.auth_token, "envtok")
+
+    def test_author_defaults_to_anonymous(self):
+        engine = LoggerEngine(server_url=UNREACHABLE, heartbeat_interval=None)
+        self.assertEqual(engine.author_username, "anonymous")
+
+    def test_run_id_auto_generated(self):
+        engine = LoggerEngine(server_url=UNREACHABLE, heartbeat_interval=None)
+        self.assertTrue(engine.run_id.startswith("run_"))
+
+    def test_run_id_from_arg(self):
+        engine = LoggerEngine(
+            server_url=UNREACHABLE, run_id="my_run", heartbeat_interval=None,
+        )
+        self.assertEqual(engine.run_id, "my_run")
+
+    def test_metadata_from_arg(self):
+        engine = LoggerEngine(
+            server_url=UNREACHABLE,
+            metadata={"gpu": "A100"},
+            heartbeat_interval=None,
+        )
+        self.assertEqual(engine.metadata, {"gpu": "A100"})
+
+    def test_metadata_from_env(self):
+        with mock.patch.dict(
+            os.environ, {"MESSENGER_LOGGER_METADATA": '{"k": "v"}'}
+        ):
+            engine = LoggerEngine(server_url=UNREACHABLE, heartbeat_interval=None)
+            self.assertIn("k", engine.metadata)
+
+    def test_metadata_env_merge(self):
+        with mock.patch.dict(
+            os.environ, {"MESSENGER_LOGGER_METADATA": '{"env_key": 1}'}
+        ):
+            engine = LoggerEngine(
+                server_url=UNREACHABLE,
+                metadata={"arg_key": 2},
+                heartbeat_interval=None,
+            )
+            self.assertIn("arg_key", engine.metadata)
+            self.assertIn("env_key", engine.metadata)
+
+
+class TestEnginePayload(unittest.TestCase):
+    def setUp(self):
+        self.engine = LoggerEngine(
+            server_url=UNREACHABLE,
+            project_name="p",
+            run_id="r",
+            auth_token="secret",
+            author_username="user",
+            metadata={"hw": "gpu"},
+            heartbeat_interval=None,
+        )
+
+    def test_send_event_constructs_payload(self):
+        with mock.patch.object(self.engine, "_send_payload") as m:
+            self.engine.send_event(
+                "trainer_log",
+                trainer_state={"global_step": 5},
+                logs={"loss": 0.1},
+            )
+            payload = m.call_args[0][0]
+            self.assertEqual(payload["project_name"], "p")
+            self.assertEqual(payload["run_id"], "r")
+            self.assertEqual(payload["event_type"], "trainer_log")
+            self.assertEqual(payload["logs"], {"loss": 0.1})
+            self.assertEqual(payload["trainer_state"]["global_step"], 5)
+            self.assertIn("timestamp", payload)
+
+    def test_final_payload_includes_author_and_metadata(self):
+        with mock.patch("messenger_logger.engine.requests.post") as m:
+            m.return_value = mock.Mock(status_code=200)
+            m.return_value.raise_for_status = mock.Mock()
+            self.engine.send_event("heartbeat")
+            call_kwargs = m.call_args
+            sent = call_kwargs.kwargs["json"]
+            self.assertEqual(sent["author_username"], "user")
+            self.assertEqual(sent["hw"], "gpu")
+
+    def test_auth_header_set(self):
+        with mock.patch("messenger_logger.engine.requests.post") as m:
+            m.return_value = mock.Mock(status_code=200)
+            m.return_value.raise_for_status = mock.Mock()
+            self.engine.send_event("heartbeat")
+            headers = m.call_args.kwargs["headers"]
+            self.assertEqual(headers["Authorization"], "Bearer secret")
+
+    def test_clearml_link_included_when_set(self):
+        self.engine.clearml_link = "https://app.clear.ml/task/123"
+        with mock.patch.object(self.engine, "_send_payload") as m:
+            self.engine.send_event("trainer_log")
+            payload = m.call_args[0][0]
+            self.assertEqual(payload["clearml_link"], "https://app.clear.ml/task/123")
+
+    def test_clearml_link_absent_when_none(self):
+        self.engine.clearml_link = None
+        with mock.patch.object(self.engine, "_send_payload") as m:
+            self.engine.send_event("trainer_log")
+            payload = m.call_args[0][0]
+            self.assertNotIn("clearml_link", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,71 @@
+"""Test that the heartbeat thread starts, fires, and stops correctly."""
+
+import time
+import unittest
+from unittest import mock
+
+from messenger_logger.engine import LoggerEngine
+
+
+UNREACHABLE = "http://localhost:19999/api/logs"
+
+
+class TestHeartbeat(unittest.TestCase):
+    def test_heartbeat_fires(self):
+        engine = LoggerEngine(
+            server_url=UNREACHABLE,
+            project_name="hb_test",
+            heartbeat_interval=1,
+        )
+        with mock.patch.object(engine, "_send_payload") as m:
+            engine.start_heartbeat()
+            time.sleep(2.5)
+            engine.stop_heartbeat()
+            heartbeat_calls = [
+                c for c in m.call_args_list
+                if c[0][0].get("event_type") == "heartbeat"
+            ]
+            self.assertGreaterEqual(len(heartbeat_calls), 1)
+
+    def test_heartbeat_stops(self):
+        engine = LoggerEngine(
+            server_url=UNREACHABLE,
+            project_name="hb_test",
+            heartbeat_interval=1,
+        )
+        with mock.patch.object(engine, "_send_payload") as m:
+            engine.start_heartbeat()
+            time.sleep(1.5)
+            engine.stop_heartbeat()
+            count_after_stop = len(m.call_args_list)
+            time.sleep(2)
+            self.assertEqual(len(m.call_args_list), count_after_stop)
+
+    def test_heartbeat_disabled(self):
+        engine = LoggerEngine(
+            server_url=UNREACHABLE,
+            project_name="hb_test",
+            heartbeat_interval=None,
+        )
+        with mock.patch.object(engine, "_send_payload") as m:
+            engine.start_heartbeat()
+            time.sleep(1)
+            engine.stop_heartbeat()
+            heartbeat_calls = [
+                c for c in m.call_args_list
+                if c[0][0].get("event_type") == "heartbeat"
+            ]
+            self.assertEqual(len(heartbeat_calls), 0)
+
+    def test_stop_without_start(self):
+        """stop_heartbeat should be safe to call even if never started."""
+        engine = LoggerEngine(
+            server_url=UNREACHABLE,
+            project_name="hb_test",
+            heartbeat_interval=60,
+        )
+        engine.stop_heartbeat()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,44 @@
+"""Verify that both interfaces import correctly."""
+
+import unittest
+import sys
+from unittest import mock
+
+
+class TestImports(unittest.TestCase):
+    def test_standalone_import(self):
+        from messenger_logger import MessengerLogger
+        self.assertTrue(callable(MessengerLogger))
+
+    def test_callback_import(self):
+        from messenger_logger.callback import MessengerLoggerCallback
+        self.assertTrue(callable(MessengerLoggerCallback))
+
+    def test_engine_import(self):
+        from messenger_logger.engine import LoggerEngine
+        self.assertTrue(callable(LoggerEngine))
+
+    def test_top_level_reexports(self):
+        import messenger_logger
+        self.assertTrue(hasattr(messenger_logger, "MessengerLogger"))
+        self.assertTrue(hasattr(messenger_logger, "MessengerLoggerCallback"))
+
+    def test_import_without_transformers(self):
+        """MessengerLogger must be importable even if transformers is missing."""
+        mods_to_clear = [
+            k for k in sys.modules if k.startswith("messenger_logger")
+        ]
+        saved = {}
+        for k in mods_to_clear:
+            saved[k] = sys.modules.pop(k)
+
+        try:
+            with mock.patch.dict(sys.modules, {"transformers": None}):
+                from messenger_logger import MessengerLogger  # noqa: F811
+                self.assertTrue(callable(MessengerLogger))
+        finally:
+            sys.modules.update(saved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone_logger.py
+++ b/tests/test_standalone_logger.py
@@ -1,0 +1,81 @@
+"""Test the standalone MessengerLogger against an unreachable server.
+
+Every method must complete without raising, printing connection errors
+to stdout instead of crashing the training process.
+"""
+
+import unittest
+from unittest import mock
+
+from messenger_logger import MessengerLogger
+
+
+UNREACHABLE = "http://localhost:19999/api/logs"
+
+
+class TestStandaloneLogger(unittest.TestCase):
+    def setUp(self):
+        self.logger = MessengerLogger(
+            server_url=UNREACHABLE,
+            project_name="test_project",
+            run_id="test_run",
+            author_username="tester",
+            heartbeat_interval=None,
+        )
+
+    def test_properties(self):
+        self.assertEqual(self.logger.project_name, "test_project")
+        self.assertEqual(self.logger.run_id, "test_run")
+
+    def test_start_does_not_crash(self):
+        self.logger.start()
+
+    def test_log_does_not_crash(self):
+        self.logger.start()
+        self.logger.log(step=1, metrics={"loss": 0.5}, epoch=0.1)
+
+    def test_epoch_end_does_not_crash(self):
+        self.logger.start()
+        self.logger.epoch_end(epoch=1)
+
+    def test_log_custom_does_not_crash(self):
+        self.logger.log_custom({"key": "value"})
+
+    def test_log_custom_rejects_non_dict(self):
+        self.logger.log_custom("not a dict")
+
+    def test_finish_does_not_crash(self):
+        self.logger.start()
+        self.logger.finish()
+
+    def test_full_lifecycle(self):
+        self.logger.start()
+        self.logger.log(step=1, metrics={"loss": 0.9}, epoch=0.0)
+        self.logger.log(step=2, metrics={"loss": 0.7}, epoch=0.5)
+        self.logger.epoch_end(epoch=1)
+        self.logger.log_custom({"checkpoint": "/tmp/best"})
+        self.logger.finish()
+
+    def test_send_event_payload(self):
+        """Verify the payload structure passed to _send_payload."""
+        with mock.patch.object(self.logger._engine, "_send_payload") as m:
+            self.logger.start()
+            call_args = m.call_args[0][0]
+            self.assertEqual(call_args["event_type"], "training_started")
+            self.assertEqual(call_args["project_name"], "test_project")
+            self.assertEqual(call_args["run_id"], "test_run")
+            self.assertIn("trainer_state", call_args)
+            self.assertTrue(call_args["trainer_state"]["is_training"])
+
+    def test_log_payload_contains_metrics(self):
+        with mock.patch.object(self.logger._engine, "_send_payload") as m:
+            self.logger.log(step=5, metrics={"loss": 0.3, "lr": 1e-4}, epoch=1.0)
+            call_args = m.call_args[0][0]
+            self.assertEqual(call_args["event_type"], "trainer_log")
+            self.assertEqual(call_args["logs"], {"loss": 0.3, "lr": 1e-4})
+            self.assertEqual(call_args["trainer_state"]["global_step"], 5)
+            self.assertEqual(call_args["trainer_state"]["epoch"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Refactored into a shared `LoggerEngine` with two user-facing interfaces:
  - `MessengerLogger` -- standalone API for any training loop (`start`, `log`, `epoch_end`, `finish`)
  - `MessengerLoggerCallback` -- HF Trainer callback (unchanged public API, backwards compatible)
- Added background heartbeat thread (60s default) for faster stall detection on the server
- Auto-detect ClearML task URL and include in payloads
- `transformers` is now an optional dependency (`pip install messenger-logger-callback[trainer]`)
- Added `__init__.py` with clean re-exports
- Bumped version to 0.2.0
- Rewrote README covering both interfaces, heartbeat, ClearML, and configuration
- Added `.gitignore`

## Test plan

- [x] Both interfaces import correctly
- [x] All methods (start, log, epoch_end, log_custom, finish, on_train_begin, on_log, etc.) handle unreachable server without crashing
- [x] Heartbeat thread starts on `start()`, fires periodically, stops on `finish()`, process exits cleanly
- [x] Package imports gracefully when `transformers` is not installed (only `MessengerLogger` available)


Made with [Cursor](https://cursor.com)