### PR TITLE
v0.2.1: Standalone logger, shared engine, heartbeat, ClearML, and SEO improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           pip install pytest
-          pip install .[trainer]
+          pip install .
         timeout-minutes: 10
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main, "feature/**"]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
-# Messenger Logger Callback
+# messenger-logger-callback
 
-A Python library for sending training logs to a remote server. Works as a **standalone logger** for any training loop or as a **Hugging Face Trainer Callback**.
+[![PyPI version](https://img.shields.io/pypi/v/messenger-logger-callback.svg)](https://pypi.org/project/messenger-logger-callback/)
+[![Python](https://img.shields.io/pypi/pyversions/messenger-logger-callback.svg)](https://pypi.org/project/messenger-logger-callback/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-Pairs with [telegram-log-service](https://github.com/Riko0/telegram_log_service) for real-time Telegram alerts.
+**messenger-logger-callback** (`messenger_logger_callback`) — a Python library for sending training logs to a remote server with real-time **Telegram** notifications. Works as a **standalone logger** for any training loop (PyTorch, Lightning, custom) or as a **Hugging Face Trainer Callback**.
+
+Pairs with [telegram-log-service](https://github.com/Riko0/telegram_log_service) for real-time Telegram bot alerts, metric monitoring, and stalled run detection.
 
 ## Installation
 
 ```bash
-# Standalone (no transformers dependency)
 pip install messenger-logger-callback
-
-# With Hugging Face Trainer support
-pip install messenger-logger-callback[trainer]
 ```
+
+Or equivalently:
+
+```bash
+pip install messenger_logger_callback
+```
+
+This installs everything including Hugging Face Transformers Trainer support. If you only need the standalone logger and want to avoid the `transformers` dependency, install with `--no-deps` and add `requests` and `python-dotenv` manually.
 
 ## Quick Start: Standalone Logger
 
@@ -135,6 +143,14 @@ Error: Could not connect to server at http://... for step 20.
 Error: HTTP error occurred while sending logs for step 30. Status: 401.
 ```
 
+## Related Projects
+
+- **[telegram-log-service](https://github.com/Riko0/telegram_log_service)** — the server that receives logs from this library and forwards them as Telegram bot alerts.
+
 ## License
 
 MIT
+
+---
+
+<sub>messenger-logger-callback · messenger_logger_callback · pip install messenger-logger-callback · pip install messenger_logger_callback · Telegram training logger · Hugging Face Trainer callback logger · ML training Telegram notifications</sub>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,28 +4,61 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "messenger-logger-callback"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Riko0", email="grigoriyalexeenko@gmail.com" },
 ]
-description = "A training logger with Hugging Face Trainer integration and standalone API for sending logs to a remote server."
+description = "Messenger Logger Callback — send training logs to Telegram via a remote server. Standalone logger and Hugging Face Trainer callback."
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
+keywords = [
+    "messenger-logger-callback",
+    "messenger_logger_callback",
+    "messenger logger callback",
+    "telegram",
+    "training",
+    "logger",
+    "callback",
+    "huggingface",
+    "transformers",
+    "machine learning",
+    "deep learning",
+    "training monitor",
+    "training logs",
+    "telegram bot",
+    "clearml",
+    "pytorch",
+]
 classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Logging",
+    "Topic :: System :: Monitoring",
 ]
 dependencies = [
     "requests>=2.25.1",
     "python-dotenv>=1.0.0",
+    "transformers>=4.0.0",
 ]
 
 [project.optional-dependencies]
-trainer = ["transformers>=4.0.0"]
+standalone = []
 
 [project.urls]
-Homepage = "https://github.com/Riko0/messenger-logger-callback"
-"Bug Tracker" = "https://github.com/Riko0/messenger-logger-callback/issues"
+Homepage = "https://github.com/Riko0/messenger_logger_callback"
+Repository = "https://github.com/Riko0/messenger_logger_callback"
+"Bug Tracker" = "https://github.com/Riko0/messenger_logger_callback/issues"
+Documentation = "https://github.com/Riko0/messenger_logger_callback#readme"
+"Telegram Log Service" = "https://github.com/Riko0/telegram_log_service"


### PR DESCRIPTION
## Summary

- **Standalone logger**: New `MessengerLogger` class with simple `start()` / `log()` / `finish()` API for any training loop (PyTorch, Lightning, custom) — no Hugging Face dependency required at runtime.
- **Shared engine**: Extracted core logic into `LoggerEngine` so both `MessengerLoggerCallback` (HF Trainer) and `MessengerLogger` (standalone) share the same config resolution, HTTP transport, ClearML detection, and heartbeat implementation.
- **Heartbeat**: Background thread sends periodic signals to the server (default 60s) for faster stalled-run detection. On by default, configurable or disableable.
- **ClearML integration**: Automatically detects active ClearML tasks and includes the dashboard link in every payload.
- **Default `transformers` dependency**: `pip install messenger-logger-callback` now includes Trainer support out of the box.
- **Discoverability**: Added PyPI keywords, extended classifiers, badges, both install name variants in README, GitHub repo description/topics, and cross-links to `telegram_log_service`.
- **Tests & CI**: Unit tests for engine, callback, standalone logger, heartbeat, and imports. GitHub Actions workflow across Python 3.9–3.12.
- **Process rank guard**: Logs are only sent from process rank zero (multi-GPU safe).

## Test plan

- [x] Unit tests pass locally (`pytest tests/ -v`)
- [ ] CI workflow passes on GitHub (Python 3.9, 3.10, 3.11, 3.12)
- [ ] Verify `pip install .` installs correctly with `transformers`
- [ ] Verify standalone logger works without HF Trainer
- [ ] Verify callback still works as drop-in for HF Trainer


Made with [Cursor](https://cursor.com)